### PR TITLE
isItemLoaded always false (bug fix)

### DIFF
--- a/src/components/InfiniteMoviesList.js
+++ b/src/components/InfiniteMoviesList.js
@@ -107,7 +107,7 @@ class InfiniteMoviesList extends React.PureComponent {
               <InfiniteLoader
                 ref={this.infiniteLoaderRef}
                 itemCount={rowCount}
-                isItemLoaded={({index}) => {
+                isItemLoaded={index => {
                   const {hasMore, movies} = this.props;
                   const maxItemsPerRow = getMaxItemsAmountPerRow(width);
                   const allItemsLoaded = generateIndexesForRow(index, maxItemsPerRow, movies.length).length > 0;


### PR DESCRIPTION
The value of the index was undefined and as a result "isItemLoaded" was always  false. Added a fix.